### PR TITLE
Update my.cnf

### DIFF
--- a/install/mysql/my.cnf
+++ b/install/mysql/my.cnf
@@ -7,6 +7,9 @@ pid-file= /var/lib/mysql/mysql.pid
 socket= /var/lib/mysql/mysql.sock
 port= 3306
 datadir= /var/lib/mysql
+collation-server = utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server = utf8mb4
 
 
 [mysqld1]
@@ -15,3 +18,6 @@ pid-file= /var/lib/mysql1/mysql.pid
 socket= /var/lib/mysql1/mysql.sock
 port= 3307
 datadir= /var/lib/mysql1
+collation-server = utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server = utf8mb4


### PR DESCRIPTION
Set MariaDB to default to utf8mb4_unicode_ci collation and utf8mb4 which are the currently recommended defaults for lots of CMS and scripts. These support all the proper language sets across the board.
https://mariadb.com/kb/en/library/setting-character-sets-and-collations/#example-changing-the-default-character-set-to-utf-8